### PR TITLE
Add basic unit tests

### DIFF
--- a/component/progress_bar_test.go
+++ b/component/progress_bar_test.go
@@ -1,0 +1,16 @@
+package component
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestProgressBarUpdate(t *testing.T) {
+	pb := NewProgressBar(100)
+	pb.UpdateProgressBar(10)
+	got := pb.GetProgressBarInstance().GetText(false)
+	expected := "[green:]" + strings.Repeat("|", 10) + "[white:]" + strings.Repeat(" ", 90)
+	if got != expected {
+		t.Errorf("unexpected progress bar text: %q", got)
+	}
+}

--- a/pages/healthcheck/consul_test.go
+++ b/pages/healthcheck/consul_test.go
@@ -1,0 +1,20 @@
+package healthcheck
+
+import "testing"
+
+func TestConsulHealth_buildColorStatus(t *testing.T) {
+	h := ConsulHealth{}
+	cases := map[int]string{
+		0:  "[white]None",
+		1:  "[green]Alive",
+		2:  "[orange]Leaving",
+		3:  "[red]Left",
+		4:  "[red]Failed",
+		99: "[white]None",
+	}
+	for in, expect := range cases {
+		if got := h.buildColorStatus(in); got != expect {
+			t.Errorf("status %d expected %s, got %s", in, expect, got)
+		}
+	}
+}

--- a/pages/healthcheck/service_test.go
+++ b/pages/healthcheck/service_test.go
@@ -1,0 +1,42 @@
+package healthcheck
+
+import "testing"
+
+func TestServiceHealth_buildColorStatus(t *testing.T) {
+	h := ServiceHealth{}
+	cases := map[string]string{
+		"passing":  "[green]passing",
+		"warning":  "[orange]warning",
+		"critical": "[red]critical",
+		"unknown":  "[white]None",
+	}
+	for in, expect := range cases {
+		if got := h.buildColorStatus(in); got != expect {
+			t.Errorf("input %s: expected %s, got %s", in, expect, got)
+		}
+	}
+}
+
+func TestServiceHealth_getServiceFullName(t *testing.T) {
+	h := ServiceHealth{}
+	tests := map[string][]string{
+		"mysql-80":      {"mysql"},
+		"mongodb-27017": {"mongodb"},
+		"nodeman":       {"nodeman"},
+		"job-gateway":   {"job", "gateway"},
+		"gse-agent":     {"gse"},
+		"bk-cmdb":       {"bk", "cmdb"},
+	}
+	for input, expect := range tests {
+		got := h.getServiceFullName(input)
+		if len(got) != len(expect) {
+			t.Fatalf("input %s expected %v got %v", input, expect, got)
+		}
+		for i, v := range expect {
+			if got[i] != v {
+				t.Errorf("input %s expect %v got %v", input, expect, got)
+				break
+			}
+		}
+	}
+}

--- a/utils/colorize_test.go
+++ b/utils/colorize_test.go
@@ -1,0 +1,33 @@
+package utils
+
+import "testing"
+
+func TestColorize(t *testing.T) {
+	got := Colorize("hello", Red)
+	expected := "\x1b[31mhello\x1b[0m"
+	if got != expected {
+		t.Errorf("expected %q, got %q", expected, got)
+	}
+
+	if Colorize("world", 0) != "world" {
+		t.Errorf("colorize with 0 should return input unchanged")
+	}
+}
+
+func TestANSIColorize(t *testing.T) {
+	got := ANSIColorize("hi", 120)
+	expected := "\x1b[38;5;120mhi\x1b[0m"
+	if got != expected {
+		t.Errorf("expected %q, got %q", expected, got)
+	}
+}
+
+func TestHighlight(t *testing.T) {
+	in := []byte("abc")
+	out := Highlight(in, []int{1}, 200)
+	expected := append([]byte{'a'}, []byte("\x1b[38;5;209mb\x1b[0m")...)
+	expected = append(expected, 'c')
+	if string(out) != string(expected) {
+		t.Errorf("expected %q, got %q", expected, out)
+	}
+}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,0 +1,19 @@
+package utils
+
+import "testing"
+
+func TestMakeHealthText(t *testing.T) {
+	got := MakeHealthText("ok")
+	expected := "[green][✔] ok"
+	if got != expected {
+		t.Errorf("expected %q, got %q", expected, got)
+	}
+}
+
+func TestMakeWarnText(t *testing.T) {
+	got := MakeWarnText("fail")
+	expected := "[red][✔] fail"
+	if got != expected {
+		t.Errorf("expected %q, got %q", expected, got)
+	}
+}


### PR DESCRIPTION
## Summary
- add unit tests for progress bar component
- add unit tests for utility color functions
- add unit tests for service helpers in healthcheck package

## Testing
- `go test -mod=mod ./...`

------
https://chatgpt.com/codex/tasks/task_e_6858b820b0d8832589c8eb457590ae79